### PR TITLE
fix: fix README badges for crate/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/iduartgomez/automatic-coding-agent/workflows/CI/badge.svg)](https://github.com/iduartgomez/automatic-coding-agent/actions?query=workflow%3ACI)
 [![Security Audit](https://github.com/iduartgomez/automatic-coding-agent/workflows/Security%20Audit/badge.svg)](https://github.com/iduartgomez/automatic-coding-agent/actions?query=workflow%3A%22Security+Audit%22)
-[![Crates.io](https://img.shields.io/crates/v/automatic-coding-agent.svg)](https://crates.io/crates/automatic-coding-agent)
-[![Documentation](https://docs.rs/automatic-coding-agent/badge.svg)](https://docs.rs/automatic-coding-agent)
+[![Crates.io](https://img.shields.io/crates/v/aca.svg)](https://crates.io/crates/aca)
+[![Documentation](https://docs.rs/aca/badge.svg)](https://docs.rs/aca)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A Rust-based agentic tool that automates coding tasks using multiple LLM providers. The system operates with dynamic task trees, comprehensive session persistence, and full resumability for long-running automated coding sessions. Features a provider-agnostic LLM interface supporting Claude Code, OpenAI Codex, and local models with both CLI and library interfaces.


### PR DESCRIPTION
## Description
This pull request updates the badges in the `README.md` to reflect the new crate name, ensuring the documentation and crate links point to the correct locations.

* Documentation and crate badge updates:
  * Changed the Crates.io and Documentation badges to use the new crate name `aca` instead of `automatic-coding-agent`, updating both the badge images and the links.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
Fixes #(issue number)
Closes #(issue number)

## Changes Made
- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Manual testing performed
- [ ] Performance impact assessed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Performance Impact
- [ ] No performance impact
- [ ] Performance improvement
- [ ] Minor performance degradation (acceptable)
- [ ] Significant performance impact (requires discussion)

## Breaking Changes
If this PR introduces breaking changes, please describe them here and provide migration instructions.

## Screenshots/Examples
If applicable, add screenshots or code examples to help explain your changes.

## Additional Notes
Add any additional notes, considerations, or context here.