### PR TITLE
docs: fix typo in CONTAINER_TESTING_GUIDE.md

### DIFF
--- a/docs/CONTAINER_TESTING_GUIDE.md
+++ b/docs/CONTAINER_TESTING_GUIDE.md
@@ -301,7 +301,7 @@ To enable in CI, ensure:
 
 ## Next Steps
 
-After verifying the tests passe
+After verifying the tests pass:
 
 1. **Read the API docs**: `cargo doc --open --features containers`
 2. **Try the examples**: See `examples/container_usage.rs` (if exists)


### PR DESCRIPTION
## Summary
Fixes incomplete sentence at line 304 of `docs/CONTAINER_TESTING_GUIDE.md`.

## Changes
- Changed "After verifying the tests passe" to "After verifying the tests pass:"

## Testing
- [x] Verified the sentence is now complete and grammatically correct
- [x] No code changes, documentation only

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)