### PR TITLE
refactor: create DEFAULT_CONTAINER_IMAGE constant

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -128,7 +128,7 @@ pub enum Commands {
         #[arg(long = "use-containers")]
         use_containers: bool,
         /// Container image to use (default: alpine:latest)
-        #[arg(long = "container-image", default_value = "alpine:latest")]
+        #[arg(long = "container-image", default_value = crate::executor::config::DEFAULT_CONTAINER_IMAGE)]
         container_image: String,
     },
     /// Run in interactive mode

--- a/src/executor/config.rs
+++ b/src/executor/config.rs
@@ -5,6 +5,9 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Default container image for isolated execution
+pub const DEFAULT_CONTAINER_IMAGE: &str = "alpine:latest";
+
 /// Execution mode - where commands run
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -50,7 +53,7 @@ pub struct ContainerExecutionConfig {
 }
 
 fn default_image() -> String {
-    "alpine:latest".to_string()
+    DEFAULT_CONTAINER_IMAGE.to_string()
 }
 
 fn default_resource_percentage() -> f64 {

--- a/src/executor/container.rs
+++ b/src/executor/container.rs
@@ -4,6 +4,7 @@
 
 use super::{ExecutionCommand, ExecutionResult, ExecutorError};
 use crate::container::{ContainerConfig, ContainerOrchestrator, ExecConfig};
+use crate::executor::config::DEFAULT_CONTAINER_IMAGE;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -30,7 +31,7 @@ pub struct ContainerExecutorConfig {
 impl Default for ContainerExecutorConfig {
     fn default() -> Self {
         Self {
-            image: "alpine:latest".to_string(),
+            image: DEFAULT_CONTAINER_IMAGE.to_string(),
             workspace_mount: PathBuf::new(),
             aca_mount: PathBuf::new(),
             memory_bytes: None,


### PR DESCRIPTION
## Summary
Creates a single source of truth for the default container image to eliminate duplication and improve maintainability.

## Changes
- Added `pub const DEFAULT_CONTAINER_IMAGE: &str = "alpine:latest"` in `src/executor/config.rs`
- Updated `src/executor/container.rs` to use the constant
- Updated `src/cli/args.rs` to use the constant in clap's `default_value` attribute
- Updated `default_image()` function to use the constant

## Benefits
- ✅ Single source of truth for default image
- ✅ Easier to change default image in the future
- ✅ Follows DRY principle
- ✅ All tests pass
- ✅ No clippy warnings introduced

## Testing
- [x] `cargo build` succeeds
- [x] `cargo test --lib` passes (122 tests)
- [x] `cargo clippy` passes (no new warnings)

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)