### PR TITLE
fix: Dockerfile npm permission error after switching to non-root user

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -58,10 +58,10 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && python3 -m pip install --upgrade pip setuptools wheel
 
-# Install Rust toolchain
+# Install Rust toolchain (must complete all rustup commands as root)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
     && . "$HOME/.cargo/env" \
-    && rustup component add clippy rustfmt
+    && rustup component add clippy rustfmt rust-analyzer
 
 # Add Rust to PATH for all users
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -87,6 +87,16 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 RUN curl -fsSL https://claude.ai/install.sh | bash || \
     echo "Claude CLI installation requires manual setup - see https://claude.ai/code"
 
+# Install common npm packages (must run as root for global install)
+RUN npm install -g \
+    typescript \
+    ts-node \
+    eslint \
+    prettier \
+    jest \
+    webpack \
+    vite
+
 # Create workspace directory
 RUN mkdir -p /workspace
 WORKDIR /workspace
@@ -108,19 +118,9 @@ RUN useradd -m -s /bin/bash -u 1000 aca-user \
 ENV HOME=/home/aca-user
 ENV USER=aca-user
 
-# Install common language-specific tools
+# Install common language-specific tools (user-local installs)
 USER aca-user
 WORKDIR /home/aca-user
-
-# Install common npm packages
-RUN npm install -g \
-    typescript \
-    ts-node \
-    eslint \
-    prettier \
-    jest \
-    webpack \
-    vite
 
 # Install common Python packages
 RUN python3 -m pip install --user \
@@ -132,9 +132,6 @@ RUN python3 -m pip install --user \
     requests \
     numpy \
     pandas
-
-# Install Rust dev tools
-RUN rustup component add rust-analyzer
 
 # Back to root for final setup
 USER root

--- a/container/Dockerfile.alpine
+++ b/container/Dockerfile.alpine
@@ -31,10 +31,10 @@ RUN apk add --no-cache \
     bind-tools
 
 # Install Node.js 20.x LTS
+# Note: Don't upgrade npm to latest as Alpine's Node.js version may be incompatible
 RUN apk add --no-cache \
     nodejs \
     npm \
-    && npm install -g npm@latest \
     && npm install -g yarn pnpm
 
 # Install Python 3.11+

--- a/container/Dockerfile.alpine
+++ b/container/Dockerfile.alpine
@@ -44,10 +44,10 @@ RUN apk add --no-cache \
     python3-dev \
     && python3 -m pip install --break-system-packages --upgrade pip setuptools wheel
 
-# Install Rust toolchain
+# Install Rust toolchain (must complete all rustup commands as root)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
     && . "$HOME/.cargo/env" \
-    && rustup component add clippy rustfmt
+    && rustup component add clippy rustfmt rust-analyzer
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -67,6 +67,14 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Note: Claude CLI installation may require glibc (not available on Alpine by default)
 # Users should install manually if needed or use the Ubuntu-based image
 
+# Install common npm packages (must run as root for global install)
+RUN npm install -g \
+    typescript \
+    ts-node \
+    eslint \
+    prettier \
+    jest
+
 # Create workspace
 RUN mkdir -p /workspace
 WORKDIR /workspace
@@ -75,14 +83,8 @@ WORKDIR /workspace
 RUN adduser -D -u 1000 -s /bin/bash aca-user \
     && echo "aca-user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Install common npm packages
+# Install common language-specific tools (user-local installs)
 USER aca-user
-RUN npm install -g \
-    typescript \
-    ts-node \
-    eslint \
-    prettier \
-    jest
 
 # Install common Python packages
 RUN python3 -m pip install --break-system-packages --user \
@@ -90,9 +92,6 @@ RUN python3 -m pip install --break-system-packages --user \
     pylint \
     pytest \
     requests
-
-# Install Rust dev tools
-RUN rustup component add rust-analyzer
 
 # Set up entrypoint
 USER root


### PR DESCRIPTION
## Summary
- Move global npm package installation before user switch to aca-user (requires root permissions)
- Move rustup component installation (rust-analyzer) before user switch (rustup is installed in /root/.cargo)
- Fix `build_aca_base_image` to use `Dockerfile.alpine` and proper image tag when building Alpine variant
- Remove npm@latest upgrade in Alpine Dockerfile (incompatible with Alpine's packaged Node.js version)
- Applies to both Dockerfile (Ubuntu) and Dockerfile.alpine

Fixes #25

## Test plan
- [x] `test_build_aca_base_image` passes
- [x] `test_ensure_aca_base_image` passes
- [x] `test_build_aca_alpine_image` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)